### PR TITLE
Inherit from `requests.Session`

### DIFF
--- a/pendo/auth.py
+++ b/pendo/auth.py
@@ -1,0 +1,11 @@
+from requests import PreparedRequest
+from requests.auth import AuthBase
+
+
+class PendoAuth(AuthBase):
+    def __init__(self, pendo_integration_key: str) -> None:
+        self.pendo_integration_key = pendo_integration_key
+
+    def __call__(self, r: PreparedRequest) -> PreparedRequest:
+        r.headers["x-pendo-integration-key"] = self.pendo_integration_key
+        return r

--- a/pendo/main.py
+++ b/pendo/main.py
@@ -1,75 +1,97 @@
-from typing import Dict, Optional, Union
+import json
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
 
-import requests
+from requests import HTTPError, Session
+from requests.compat import urljoin
 
 from pendo.const import PENDO_URL
 from pendo.types import PendoResponse, PendoTrackEvent
 
+from .auth import PendoAuth
 from .exc import PendoException
 
 
-class Pendo:
-    """Pendo.
+class Pendo(Session):
+    """Pendo session.
 
     An unofficial Python package for server-side Pendo integrations.
 
     Attributes:
-        pendo_integration_key (str): The Pendo integration key. A Pendo Admin can
-            access this key in your app settings
-            (Subscription Settings > Choose your App > App Details).
-        extra_headers (Optional[Dict]): Extra headers to be sent with the request.
+        auth (PendoAuth): The Pendo authentication handler.
+        headers (Dict): The default headers to be sent with the request.
+        host (str): The Pendo API URL. Defaults to PENDO_URL.
     """
 
     def __init__(
-        self, pendo_integration_key: str, extra_headers: Optional[Dict] = dict()
+        self,
+        pendo_integration_key: str,
+        extra_headers: Optional[Dict] = dict(),
+        url: str = PENDO_URL,
     ) -> None:
-        self.pendo_integration_key = pendo_integration_key
-        self.extra_headers = extra_headers
+        """Pendo session constructor.
 
-    def __headers(self) -> Dict:
-        """Private method to return the headers for the request.
-
-        Returns:
-            Dict: The private headers.
+        Args:
+            pendo_integration_key (str): The Pendo integration key.
+            extra_headers (Optional[Dict], optional): Extra headers to add to each
+                request. Defaults to dict().
+            url (str, optional): The main URL used to access the Engage API corresponds
+                to the region and web address that you use when logging into Pendo's UI.
+                Defaults to PENDO_URL.
         """
-        return {
-            "Content-Type": "application/json; charset=utf-8",
-            "x-pendo-integration-key": self.pendo_integration_key,
-        }
+        super().__init__()
 
-    def headers(self) -> Dict:
-        """Return the headers for the request.
+        self.auth = PendoAuth(pendo_integration_key)
+        self.headers.update(extra_headers)  # type: ignore[arg-type]
+        self.host = url
 
-        Returns:
-            Dict: The headers.
-        """
-        if self.extra_headers:
-            return {**self.extra_headers, **self.__headers()}
-        return self.__headers()
-
-    def track(
-        self, event: Union[Dict, PendoTrackEvent], url: Optional[str] = None
+    def request(  # type: ignore[override]
+        self, method: str, path: str, *args: Any, **kwargs: Any
     ) -> PendoResponse:
+        """Make a request.
+
+        Args:
+            method (str): The HTTP method.
+            path (str): The endpoint to send the request to.
+            *args: Positional arguments to be passed to the request.
+            **kwargs: Keyword arguments to be passed to the request.
+
+        Raises:
+            PendoException: If the request fails.
+
+        Returns:
+            PendoResponse: The response.
+        """
+        path = urljoin(self.host, path)
+        try:
+            response = super().request(method, path, *args, **kwargs)
+            response.raise_for_status()
+        except HTTPError as exc:
+            r = exc.response
+            raise PendoException(
+                f"Request exited with status {r.status_code}: {r.reason}"
+            ) from exc
+
+        try:
+            data = response.json()
+        except json.JSONDecodeError:
+            data = {}
+
+        return PendoResponse(status_code=HTTPStatus(response.status_code), data=data)
+
+    def track(self, event: Union[Dict, PendoTrackEvent]) -> PendoResponse:
         """Track an event.
 
         Args:
             event (Union[Dict, PendoTrackEvent]): The track event to be used as a POST
                 request body.
-            url (Optional[str]): The URL to send the POST request to. Defaults to the
-                PENDO_URL constant. Defaults as None.
 
         Returns:
             PendoResponse: The response.
         """
-        if url is None:
-            url = PENDO_URL
         if isinstance(event, dict):
             event = PendoTrackEvent(**event)
-        response = requests.post(
-            f"{url}/data/track", json=event.dict(), headers=self.headers()
+
+        return self.post(  # type: ignore[return-value]
+            "data/track", json=event.model_dump()
         )
-        if not response.ok:
-            raise PendoException(
-                f"Request exited with status {response.status_code}: {response.reason}"
-            )
-        return PendoResponse(status_code=response.status_code)

--- a/pendo/types.py
+++ b/pendo/types.py
@@ -1,4 +1,5 @@
 from enum import Enum, unique
+from http import HTTPStatus
 from typing import Dict, Union
 
 from pydantic import BaseModel, StrictInt, StrictStr
@@ -28,7 +29,8 @@ class PendoTrackEvent(BaseModel):
 
 
 class Response(BaseModel):
-    status_code: StrictInt
+    status_code: HTTPStatus
+    data: dict
 
 
 class PendoResponse(Response):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,17 +9,10 @@ description = "An unofficial client for the Pendo API."
 dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.9.8"
-dependencies = [
-    "requests >=2.22.0",
-    "pydantic >=1.5.1",
-]
+dependencies = ["requests >=2.22.0", "pydantic >=1.5.1"]
 
 [project.optional-dependencies]
-test = [
-    "pytest >=6.2.5",
-    "coverage >=6.1.1",
-    "pytest-cov >=3.0.0",
-]
+test = ["pytest >=6.2.5", "coverage >=6.1.1", "pytest-cov >=3.0.0"]
 dev = [
     "flake8 >=3.9.2",
     "mypy >=0.910",
@@ -34,5 +27,19 @@ dev = [
 [tool.isort]
 profile = "black"
 
+[tool.black]
+line-length = 88
+
 [project.urls]
 Documentation = "https://www.github.com/rungalileo/pendo"
+
+[tool.pytest.ini_options]
+addopts = [
+    "--cov=pendo",
+    "--cov=tests",
+    "--cov-report=term-missing",
+    "--cov-report=xml",
+    "-o console_output_style=progress",
+    "--disable-warnings",
+    "--cov-fail-under=100",
+]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,5 @@
 import time
-from unittest import mock
+from http import HTTPStatus
 
 import pytest
 
@@ -8,29 +8,20 @@ from pendo.exc import PendoException
 from pendo.types import PendoTrackEvent
 
 
-@mock.patch(
-    "pendo.main.requests.post",
-    return_value=mock.Mock(
-        status_code=200, json=mock.Mock(return_value={"status": "ok"}), ok=True
-    ),
-)
-def test_pendo(
-    mock_post: mock.MagicMock, pendo_client: Pendo, pendo_track_event: PendoTrackEvent
-) -> None:
+def test_live_pendo(pendo_client: Pendo, pendo_track_event: PendoTrackEvent) -> None:
+    with pytest.raises(Exception):
+        pendo_client.track(event=pendo_track_event)
+
+
+@pytest.mark.usefixtures("ok_request")
+def test_pendo(pendo_client: Pendo, pendo_track_event: PendoTrackEvent) -> None:
     response = pendo_client.track(event=pendo_track_event)
-    assert response.status_code == 200
+    assert response.status_code == HTTPStatus.OK
 
 
-@mock.patch(
-    "pendo.main.requests.post",
-    return_value=mock.Mock(
-        status_code=500,
-        reason="Internal Server Error",
-        ok=False,
-    ),
-)
+@pytest.mark.usefixtures("error_request")
 def test_pendo_catch_exception(
-    mock_post: mock.MagicMock, pendo_client: Pendo, pendo_track_event: PendoTrackEvent
+    pendo_client: Pendo, pendo_track_event: PendoTrackEvent
 ) -> None:
     with pytest.raises(PendoException) as exc_info:
         pendo_client.track(event=pendo_track_event)
@@ -40,46 +31,24 @@ def test_pendo_catch_exception(
     )
 
 
-@mock.patch(
-    "pendo.main.requests.post",
-    return_value=mock.Mock(
-        status_code=200, json=mock.Mock(return_value={"status": "ok"}), ok=True
-    ),
-)
+@pytest.mark.usefixtures("ok_request")
 def test_pendo_with_extra_headers(
-    mock_post: mock.MagicMock,
-    pendo_client_extra_headers: Pendo,
-    pendo_track_event: PendoTrackEvent,
+    pendo_client_extra_headers: Pendo, pendo_track_event: PendoTrackEvent
 ) -> None:
     response = pendo_client_extra_headers.track(event=pendo_track_event)
-    assert response.status_code == 200
+    assert response.status_code == HTTPStatus.OK
 
 
-@mock.patch(
-    "pendo.main.requests.post",
-    return_value=mock.Mock(
-        status_code=200, json=mock.Mock(return_value={"status": "ok"}), ok=True
-    ),
-)
+@pytest.mark.usefixtures("ok_request")
 def test_pendo_track_event_with_props_and_context(
-    mock_post: mock.MagicMock,
-    pendo_client: Pendo,
-    pendo_track_event_with_props_and_context: PendoTrackEvent,
+    pendo_client: Pendo, pendo_track_event_with_props_and_context: PendoTrackEvent
 ) -> None:
     response = pendo_client.track(event=pendo_track_event_with_props_and_context)
-    assert response.status_code == 200
+    assert response.status_code == HTTPStatus.OK
 
 
-@mock.patch(
-    "pendo.main.requests.post",
-    return_value=mock.Mock(
-        status_code=200, json=mock.Mock(return_value={"status": "ok"}), ok=True
-    ),
-)
-def test_pendo_track_event_dict_input(
-    mock_post: mock.MagicMock,
-    pendo_client: Pendo,
-) -> None:
+@pytest.mark.usefixtures("ok_request")
+def test_pendo_track_event_dict_input(pendo_client: Pendo) -> None:
     response = pendo_client.track(
         {
             "event": "TestEvent",
@@ -88,19 +57,11 @@ def test_pendo_track_event_dict_input(
             "timestamp": int(time.time() * 1000),
         }
     )
-    assert response.status_code == 200
+    assert response.status_code == HTTPStatus.OK
 
 
-@mock.patch(
-    "pendo.main.requests.post",
-    return_value=mock.Mock(
-        status_code=200, json=mock.Mock(return_value={"status": "ok"}), ok=True
-    ),
-)
-def test_pendo_track_event_custom_event(
-    mock_post: mock.MagicMock,
-    pendo_client: Pendo,
-) -> None:
+@pytest.mark.usefixtures("ok_request")
+def test_pendo_track_event_custom_event(pendo_client: Pendo) -> None:
     response = pendo_client.track(
         {
             "event": "TestEvent",
@@ -111,4 +72,4 @@ def test_pendo_track_event_custom_event(
             "context": {"more": "more", "testing": "testing", "one": {"two": "three"}},
         }
     )
-    assert response.status_code == 200
+    assert response.status_code == HTTPStatus.OK


### PR DESCRIPTION
* [x] I have added tests to `tests` to cover my changes.
* [ ] I have added `docs/`, if necessary.
* [ ] I have updated the `README.md`, if necessary.
* [ ] I have updated the `CONTRIBUTING.md`, if necessary.

## What issue does this pull request close?

Closes #2

## How are these changes tested?

The existing tests were refactored to use `pytest.monkeypatch` fixtures to mock requests rather than `unittest.mock`, which is more appropriate for projects that primarily use `pytest`.

## Changelog
The primary purpose of this PR is to make this library far more extensible and more in-line with the Requests library. With these changes, adding additional endpoint methods to the client should be very straightforward and DRY.

- Pendo client now inherits from `requests.Session`
- Added an auth handler class to add required auth headers
- Base URL optionally passed to client constructor
- Request handling moved to `Pendo.request`
  - This centralizes all request logic and makes this library far more extensible
  - Handles URL compilation
  - Requests now try to resolve the json payload, passing resolved data to `PendoRequest`
  - Headers automatically handled by the underlying `Session` (`Content-Type`, `charset`)
- Added `data` attribute to `Request` type
- Use `HTTPStatus` for status code validation
- Replaced all instances of `unittest.Mock` with `pytest.monkeypatch` fixtures
- Added a test to ensure live API calls are blocked
